### PR TITLE
test,ci: スモークテストと CI を追加（現代化 Step 0）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+# CI 標準テンプレート(masatomix/task#1055 Phase 1 / #1056 現代化 Step 0)。
+# 現時点のベースライン(Spring Boot 3.1.2 / Java 17)を検証する。
+# Java バージョンは現代化の各ステップ(Step 3 で 21 へ)に合わせて更新する。
+name: CI
+
+on:
+  push:
+    branches: [develop, master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Build & test
+        run: mvn -B verify

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,9 @@ hs_err_pid*
 
 target/
 
+# 環境変数・ローカル設定・ログ(task#1056 Step 0)
+.env
+.env.local
+*.log
+.DS_Store
+

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
 			<artifactId>jaxb-runtime</artifactId>
 			<version>2.3.2</version>
 		</dependency>
+		<!-- ※未検証・参考: Redis セッションを使う場合の依存。本サンプルでは無効化したまま残す。 -->
 		<!-- <dependency>
 			<groupId>org.springframework.session</groupId>
 			<artifactId>spring-session-data-redis</artifactId>
@@ -123,6 +124,13 @@
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
 		</dependency> -->
+
+		<!-- テスト（スモークテストの安全網。task#1056 Step 0） -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<!-- Package as an executable jar -->

--- a/src/test/java/nu/mine/kino/SmokeTest.java
+++ b/src/test/java/nu/mine/kino/SmokeTest.java
@@ -1,0 +1,64 @@
+package nu.mine.kino;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 現代化リファクタリング（task#1056）の安全網となるスモークテスト。
+ *
+ * <p>JWT 検証を伴わない公開エンドポイントのみを対象に、アプリケーションコンテキストの
+ * 起動と基本的なリクエスト/レスポンスの疎通を確認する。後続フェーズ（jakarta 統一・
+ * Spring Boot 4.0 への更新・JWT 検証の resource-server 化）でこれらが壊れていないことの
+ * リグレッション基準とする。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class SmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    /** コンテキストが正常に起動し、MockMvc が注入されること。 */
+    @Test
+    void contextLoads() throws Exception {
+        // @Autowired の MockMvc が解決できれば、SpringBootApplication の起動は成功している。
+    }
+
+    /** GET /status が "hello" を返すこと。 */
+    @Test
+    void statusReturnsHello() throws Exception {
+        mockMvc.perform(get("/status"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("hello"));
+    }
+
+    /** GET /echo2 が "hello!!!" を返すこと。 */
+    @Test
+    void echo2GetReturnsHello() throws Exception {
+        mockMvc.perform(get("/echo2"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("hello!!!"));
+    }
+
+    /** POST /echo2 が送信した JSON をそのままエコーすること。 */
+    @Test
+    void echo2PostEchoesBody() throws Exception {
+        String body = "{\"id\":\"1\",\"name\":\"taro\"}";
+        mockMvc.perform(post("/echo2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.name").value("taro"));
+    }
+}


### PR DESCRIPTION
## 概要

spring-boot-sample-tomcat 現代化（masatomix/task#1056）の **Step 0: 安全網**。
最終ターゲット（Boot 4.0.x / Java 21 / JWT を resource-server 化）への一連の更新に先立ち、リグレッション基準となるテストと CI を整備します。

方針確定（ユーザー判断）: JWT は **案A = oauth2-resource-server 全面置換** / 最終ターゲット **Boot 4.0.x** / Redis サンプルは **コメントアウトのまま維持**。

## 変更内容

- `spring-boot-starter-test`（test scope）を追加
- `SmokeTest`: contextLoads + `/status`・`/echo2`(GET/POST) の疎通4件（JWT 不要の公開エンドポイントのみ）
- `.github/workflows/ci.yml`: `mvn -B verify`（現ベースライン Java 17 / Boot 3.1.2。Java は Step 3 で 21 へ）
- `.gitignore`: `.env` / `*.log` / `.DS_Store`
- Redis 依存のコメントに「※未検証・参考」を明記

## 検証（ローカル: Java 17）

- `mvn -B verify`: **BUILD SUCCESS / Tests run: 4, Failures: 0**

## 後続（別 PR でスタック予定）

Step 1 セキュリティ即応（Actuator 公開制限・nimbus 7→10・JWKS 外部化）→ Step 2 jakarta 統一・Jersey→RestClient → Step 3 Boot 4.0/Java 21/Docker → Step 4 JWT resource-server 化 → Step 5 重複整理・README。

🤖 Generated with [Claude Code](https://claude.com/claude-code)