### PR TITLE
fix(security): Actuator の公開を health/info に限定（Step 1）

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,11 +3,13 @@ server.compression.min-response-size: 1
 server.connection-timeout=5000
 server.port=8080
 
-# management.endpoints.web.exposure.include=beans,env,health
-# management.endpoints.enabled-by-default=true
-management.endpoints.web.exposure.include=*
-management.endpoint.env.show-values=ALWAYS
+# Actuator の公開は health / info のみに限定する（task#1056 Step 1）。
+# 以前は `*`（全エンドポイント公開）+ env.show-values=ALWAYS で、/actuator/env や
+# /actuator/heapdump 等から環境変数・メモリダンプが無認証で取得できる状態だった。
+# 追加で必要なエンドポイントがある場合のみ、明示的に列挙して許可すること。
+management.endpoints.web.exposure.include=health,info
 
+# ※未検証・参考: Redis セッションを使う場合の設定。本サンプルでは無効化したまま残す。
 # spring.session.store-type=redis
 # # Redis server host.
 # spring.data.redis.host=localhost

--- a/src/test/java/nu/mine/kino/ActuatorExposureTest.java
+++ b/src/test/java/nu/mine/kino/ActuatorExposureTest.java
@@ -1,0 +1,48 @@
+package nu.mine.kino;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Actuator の公開範囲が health / info に限定されていることのリグレッションテスト（task#1056 Step 1）。
+ *
+ * <p>以前は全エンドポイント公開だったため、/actuator/env や /actuator/heapdump 等から
+ * 環境変数・メモリダンプが無認証で取得できた。公開を絞った状態が将来も維持されることを担保する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class ActuatorExposureTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    /** health は公開されている（200）。 */
+    @Test
+    void healthIsExposed() throws Exception {
+        mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
+    }
+
+    /** env は公開されていない（404）。秘密情報の漏洩経路を塞いだことを確認する。 */
+    @Test
+    void envIsNotExposed() throws Exception {
+        mockMvc.perform(get("/actuator/env")).andExpect(status().isNotFound());
+    }
+
+    /** beans も公開されていない（404）。 */
+    @Test
+    void beansIsNotExposed() throws Exception {
+        mockMvc.perform(get("/actuator/beans")).andExpect(status().isNotFound());
+    }
+
+    /** heapdump も公開されていない（404）。 */
+    @Test
+    void heapdumpIsNotExposed() throws Exception {
+        mockMvc.perform(get("/actuator/heapdump")).andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## 概要

spring-boot-sample-tomcat 現代化（masatomix/task#1056）の **Step 1: セキュリティ即応**。Step 0（#8）マージ後の develop ベース。

## 背景

監査で、Actuator が `exposure.include=*` + `env.show-values=ALWAYS` の状態であることを検出。`/actuator/env`・`/actuator/heapdump`・`/actuator/beans` 等が**無認証で公開**され、環境変数やメモリダンプが取得できる状態でした。

## 変更内容

- `application.properties`: 公開を `health,info` のみに限定、`env.show-values=ALWAYS` を撤去
- `ActuatorExposureTest`: health=200 / env・beans・heapdump=404 をリグレッションとして固定

## 検証（ローカル: Java 17）

- `mvn -B verify`: **BUILD SUCCESS / Tests run: 8, Failures: 0**（Step 0 の 4 件 + 本 PR の 4 件）

## プラン微修正の明記

当初プラン Step 1 に含めていた **nimbus 7→10 / JWKS URL 外部化は本 PR から除外**しました。これらは `JWTUtils` を触りますが、**Step 4（案A: oauth2-resource-server 全面置換）で JWTUtils を全廃**するため捨て work になります。JWT 関連の現代化は Step 4 に集約します。Actuator のロックダウンは恒久的に有効なため Step 1 として実施します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)