### PR TITLE
build: Spring Boot 4.0 / Java 21 / Docker 現代化（Step 3）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
-# CI 標準テンプレート(masatomix/task#1055 Phase 1 / #1056 現代化 Step 0)。
-# 現時点のベースライン(Spring Boot 3.1.2 / Java 17)を検証する。
-# Java バージョンは現代化の各ステップ(Step 3 で 21 へ)に合わせて更新する。
+# CI 標準テンプレート(masatomix/task#1055 Phase 1 / #1056 現代化)。
+# Spring Boot 4.0 / Java 21（Step 3 で 17 から更新）を検証する。
 name: CI
 
 on:
@@ -16,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: maven
       - name: Build & test
         run: mvn -B verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
-# FROM maven:3.5.2-jdk-8  AS build1
-# RUN mkdir -p /opt/java/src/
-# ADD ./pom.xml /opt/java/
-# ADD ./src /opt/java/src
-# RUN cd /opt/java && mvn install
+# マルチステージビルド（task#1056 Step 3）。
+# 旧来は openjdk:17-alpine（メンテ終了イメージ）に事前ビルド済み jar を COPY する方式
+# だったが、ビルドからイメージ内で完結させ、実行は eclipse-temurin の JRE で行う。
 
-FROM openjdk:17-alpine
+# ---- build stage ----
+FROM maven:3.9-eclipse-temurin-21 AS build
+WORKDIR /workspace
+# 依存解決を先に行いレイヤキャッシュを効かせる
+COPY pom.xml .
+RUN mvn -B -q dependency:go-offline
+COPY src ./src
+# テストは CI(mvn verify)で実施済みのためイメージビルドでは省略
+RUN mvn -B -q clean package -DskipTests
+
+# ---- runtime stage ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
 VOLUME /tmp
-# ARG JAR_FILE
-# # COPY --from=build1 /opt/java/${JAR_FILE} app.jar
-# COPY ${JAR_FILE} app.jar
-
-COPY target/app.jar app.jar
+COPY --from=build /workspace/target/app.jar app.jar
 EXPOSE 8080
- 
-# ENTRYPOINT ["java","-jar","${JAVA_OPTS}","/app.jar"]
-# ENTRYPOINT ["sh","-c","java -jar /app.jar ${JAVA_OPTS}"]
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.2</version>
+		<version>4.0.7</version>
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<lombok.version>1.18.26</lombok.version>
+		<java.version>21</java.version>
 	</properties>
 
 	<!-- Add typical dependencies for a web application -->
@@ -46,29 +46,20 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+		<!-- lombok の版は Spring Boot の BOM が管理する（JDK 21 互換版が選択される。task#1056 Step 3）。 -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>${lombok.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-core</artifactId>
-			<version>1.4.11</version>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.4.11</version>
-		</dependency>
+		<!-- logback 本体は Spring Boot の BOM が管理する（明示ピンを撤去。task#1056 Step 3）。 -->
 		<!--
-			Logbackで、JSON形式のログを扱いたいとき。	
+			Logbackで、JSON形式のログを扱いたいとき。BOM 管理外のため版は明示する。
 		-->
 		<dependency>
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
-			<version>7.4</version>
+			<version>8.1</version>
 			<!-- Use runtime scope if the project does not have any compile-time usage of
 			logstash-logback-encoder,
          such as usage of StructuredArguments/Markers or implementations such as
@@ -102,6 +93,13 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- Spring Boot 4.0 で MockMvc 等の WebMVC スライステスト支援は専用スターターに
+		     分離された（@AutoConfigureMockMvc の auto-config を提供。task#1056 Step 3）。 -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 server.compression.enabled: true
 server.compression.min-response-size: 1
-server.connection-timeout=5000
 server.port=8080
 
 # JWT(Bearer トークン)検証の鍵取得元（task#1056 Step 2）。

--- a/src/test/java/nu/mine/kino/ActuatorExposureTest.java
+++ b/src/test/java/nu/mine/kino/ActuatorExposureTest.java
@@ -5,7 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/src/test/java/nu/mine/kino/EchoAuthTest.java
+++ b/src/test/java/nu/mine/kino/EchoAuthTest.java
@@ -5,7 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;

--- a/src/test/java/nu/mine/kino/SmokeTest.java
+++ b/src/test/java/nu/mine/kino/SmokeTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;


### PR DESCRIPTION
## 概要

spring-boot-sample-tomcat 現代化（masatomix/task#1056）の **Step 3**。Step 2（#10）マージ後の develop ベース。最終ターゲットの **Spring Boot 4.0.x / Java 21 LTS** に到達します。

## 変更内容

**プラットフォーム更新**
- Spring Boot **3.1.2 → 4.0.7**（Spring Framework 7）
- Java **17 → 21**
- logback の明示ピン（1.4.11）を撤去し BOM 管理へ、logstash-logback-encoder **7.4 → 8.1**
- lombok の版ピン（1.18.26）を撤去し BOM 管理へ（**1.18.26 は新しい JDK 21 で javac の NoSuchFieldError を起こす**。Docker の temurin-21 ビルドで顕在化）
- 廃止プロパティ `server.connection-timeout` を削除

**Spring Boot 4.0 のテスト変更対応**
- Boot 4.0 では `@SpringBootTest` が MockMvc を提供しなくなり、`@AutoConfigureMockMvc` の auto-config も WebMVC スライス専用スターターに分離。`spring-boot-starter-webmvc-test`(test) を追加し、import を新パッケージ `org.springframework.boot.webmvc.test.autoconfigure` へ変更

**Docker**
- 単段（`openjdk:17-alpine`〔メンテ終了〕+ 事前ビルド jar の COPY）→ `maven:3.9-eclipse-temurin-21` でビルドし `eclipse-temurin:21-jre` で実行する**マルチステージ**構成へ

## 検証（ローカル）

- `mvn -B verify`（Java 21）: **Tests run: 10, Failures: 0**
- `docker build` 成功 + **コンテナ起動で実動作確認**: `/status`=hello / `/actuator/health`=UP / `/actuator/env`=404（CI は Docker をビルドしないため手動検証）

## 後続

Step 4（最終）: `/echo`・`/echo2`・`/echoBody` の重複整理（or README 明記）、EchoController の `System.out` → slf4j とコメントアウト済みデッドコード削除、README の Redis 節・バージョン記述の同期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)