### PR TITLE
docs,refactor: README 同期と EchoController クリーンアップ（Step 4・最終）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,85 @@
+# spring-boot-sample-tomcat
 
-### 実行
+Spring Boot の Web アプリケーションサンプル。REST API・JWT(Bearer トークン)認証・
+Actuator・JSON 形式ログ・Docker 化のデモを含む。
+
+- Spring Boot 4.0 / Java 21
+- JWT 検証は Spring Security の OAuth2 Resource Server（Firebase の JWK Set を利用）
+- ログは logback + logstash-logback-encoder（JSON 出力に対応）
+
+## 必要環境
+
+- Java 21
+- Maven 3.9+
+- （任意）Docker
+
+## 実行
 
 ```bash
-$ git clone https://github.com/masatomix/spring-boot-sample-tomcat.git  ← 実際はほしいbranchを取得
-$ cd spring-boot-sample-tomcat
-# $ mvn eclipse:clean eclipse:eclipse
+# 開発実行
 $ mvn spring-boot:run
+
+# jar を作成して実行（profile 指定例）
+$ mvn package
+$ java -jar ./target/app.jar --spring.profiles.active=dev
 ```
 
-### jar作成して、実行
+`target/app.jar` が実行可能 jar（組み込み Tomcat）。
 
+## エンドポイント
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| GET | `/status` | 不要 | 死活確認。`hello` を返す |
+| POST | `/echo` | **JWT 必須** | Bearer トークン検証後、受領した JSON を返す |
+| GET/POST | `/echo2` | 不要 | GET は `hello!!!`、POST は受領 JSON を返す |
+| POST | `/echoBody` | 不要 | 受領した JSON を返す |
+| GET | `/echoLogger`, `/echoLogger1` | 不要 | ログレベル(DEBUG/INFO/WARN/ERROR)出力のデモ |
+| GET | `/echoSysout` | 不要 | `System.out` 出力のデモ（`/echoLogger` との対比用） |
+| POST | `/exception` | 不要 | 400/500 系エラー応答のデモ |
+| GET | `/save`, `/load` | 不要 | `HttpSession` への保存・読み出しデモ |
+| GET | `/actuator/health`, `/actuator/info` | 不要 | Actuator（公開はこの2つのみに限定） |
+
+### JWT 認証（`POST /echo`）
+
+`POST /echo` のみ有効な Bearer トークン（Firebase の ID トークン）を要求する。検証鍵は
+`application.properties` の `spring.security.oauth2.resourceserver.jwt.jwk-set-uri` から取得し、
+署名・有効期限を検証する（issuer/audience の厳密検証はプロジェクト ID を用いて設定する将来の改善）。
+
+```bash
+$ curl -X POST http://localhost:8080/echo \
+    -H "Authorization: Bearer <ID_TOKEN>" \
+    -H "Content-Type: application/json" \
+    -d '{"id":"1","name":"taro"}'
 ```
-$ mvn install
-$ java -jar ./target/app.jar --spring.profiles.active=dev  ← profileを指定する方法
+
+トークンが無い・不正な場合は 401 を返す。
+
+## Docker
+
+マルチステージビルド（`maven:3.9-eclipse-temurin-21` でビルド、`eclipse-temurin:21-jre` で実行）。
+
+```bash
+$ docker image build -t spring-boot-sample-tomcat .
+$ docker container run --rm -p 8080:8080 --name app spring-boot-sample-tomcat
 ```
 
-実行jarができていて、上記のようにTomcatサーバを起動できます。
+### ECR への手動 Push（参考）
 
-
-### dockerのイメージ作成、ECRへの手動Push、docker上で実行
-
-```
+```bash
 $ ECR_REPOSITORY_NAME=spring-boot-sample-tomcat
-$ version=0.0.3  <- pom.xmlのバージョンにあわせるのがよさそう
-
+$ version=$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout)
 $ AWS_REGION_NAME=ap-northeast-1
 $ AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
-$ aws ecr --region  ${AWS_REGION_NAME} get-login-password | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION_NAME}.amazonaws.com
-
+$ aws ecr --region ${AWS_REGION_NAME} get-login-password \
+    | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION_NAME}.amazonaws.com
 $ REPOSITORY_URI=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION_NAME}.amazonaws.com/${ECR_REPOSITORY_NAME}
-
 $ docker image build -t ${REPOSITORY_URI}:${version} .
 $ docker image push ${REPOSITORY_URI}:${version}
 ```
 
-下記の感じのコマンドでDocker上で起動ができます。
+## Redis セッション（※未検証・参考、現在は無効）
 
-```
-$ docker container run --rm -p 8080:8080 \
- --link redis:REDIS_HOST \
- -e --spring.profiles.active=dev \
- --name app \
- {REPOSITORY_URI}:${version}
-```
-
-
-### redis起動(SpringSessionなどでSessionの保存先をRedisにしている場合)
-
-```
-docker run --rm -p 6379:6379 -d --name redis redis
-```
-
-これで起動したRedisには localhost:6379 で接続できます。
-SpringBootをDockerで起動した場合は、localhostではないので、
-
-
-```
-docker run --rm -p 6379:6379 -d --name redis redis
-docker run --rm -p 8080:8080 --link redis:REDIS_HOST -e --spring.profiles.active=dev --name myapp myorg/myapp
-```
-
-などDockerのlink機能でホスト名を規定(REDIS_HOST)して、接続先を設定ファイルで切り替えます。
-上記は profileをdevにしているので、application-dev.properties に
-
-```
-# Redis server host.
-spring.data.redis.host=REDIS_HOST
-```
-
-とかしておけばOKですね。
+Spring Session でセッション保存先を Redis にする構成は、依存・設定とも**コメントアウトして無効化**
+している（`pom.xml` / `application.properties`）。有効化する場合の手順は [README_redis.md](README_redis.md) を参照。
+記載内容は更新前のもので未検証のため、利用時は最新版で確認すること。

--- a/src/main/java/nu/mine/kino/web/EchoController.java
+++ b/src/main/java/nu/mine/kino/web/EchoController.java
@@ -73,7 +73,6 @@ public class EchoController {
     @RequestMapping(value = "/echoBody", produces = "application/json; charset=utf-8", method = RequestMethod.POST)
     public Hello helloWorld(@RequestBody Hello hello) {
         log.info("{}", hello);
-        System.out.println(hello.toString());
         return hello;
     }
 
@@ -93,27 +92,6 @@ public class EchoController {
         throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "サービス停止中");
 
     }
-
-    // @ResponseBody
-    // @RequestMapping(value = "/error", produces = "application/json;
-    // charset=utf-8", method = RequestMethod.POST)
-    // public Hello helloWorld(
-    // @RequestHeader(value = "Authorization", required = true) String
-    // authorization,
-    // @RequestBody Hello hello) throws UNAUTHORIZED_Exception {
-
-    // Matcher matcher = CHALLENGE_PATTERN.matcher(authorization);
-    // if (matcher.matches()) {
-    // String id_token = matcher.group(1);
-    // if (JWTUtils.checkIdToken(id_token)) {
-    // return hello;
-    // } else {
-    // throw new UNAUTHORIZED_Exception("ID Token is invalid.");
-    // }
-    // }
-    // throw new UNAUTHORIZED_Exception(
-    // "Authorization ヘッダから、Bearerトークンを取得できませんでした。");
-    // }
 
     private String getHostName() {
         try {


### PR DESCRIPTION
## 概要

spring-boot-sample-tomcat 現代化（masatomix/task#1056）の **Step 4（最終）**。Step 3（#11）マージ後の develop ベース。

## 変更内容

- **README.md を実態に同期**: Spring Boot 4.0 / Java 21、エンドポイント一覧、JWT 認証（`POST /echo`）の説明、Docker マルチステージ手順、Redis が無効化済みである旨を明記。旧記述（version 0.0.3・Redis 前提の起動例）を是正
- **EchoController クリーンアップ**: `/echoBody` の冗長な `System.out.println` を除去（`log.info` で十分）、削除済み JWTUtils を参照する**コメントアウト済みデッドコード**（`/error` ブロック）を削除
- `/echoSysout` は `System.out` 出力の対比デモとして**意図的に残置**（README に役割を明記）

## エンドポイント重複について

`/echo`(JWT必須) / `/echo2` / `/echoBody` は当初プランで「統合 or README 明記」としていましたが、それぞれ「JWT 保護あり/なし」を示すサンプルとして価値があるため、**統合せず README で役割を明記**する方針にしました。

## 検証

- `mvn -B verify`（Java 21）: **Tests run: 10, Failures: 0**

## #1056 現代化の完了

本 PR で全 Step 完了:
- Step 0: スモークテスト + CI
- Step 1: Actuator ロックダウン
- Step 2: jakarta 統一 + JWT を oauth2-resource-server 化（旧 Step 4 を前倒し統合）
- Step 3: Spring Boot 4.0.7 / Java 21 / Docker マルチステージ
- Step 4: README 同期 + クリーンアップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)